### PR TITLE
Query properties by ID

### DIFF
--- a/src/types/item.resolvers.js
+++ b/src/types/item.resolvers.js
@@ -13,7 +13,10 @@ module.exports = {
     label: (_, args) => {
       return _.labels[args.language];
     },
-    claims: (_) => {
+    claims: (_, args) => {
+      if( args.propertyId ) {
+        return _.claims[args.propertyId];
+      }
       return [].concat(...Object.values(_.claims));
     },
     description: (_, args ) => {

--- a/src/types/item.schema.js
+++ b/src/types/item.schema.js
@@ -13,7 +13,7 @@ const typeDefs = gql`
     ## Implement those later
     description(language: String): Description
     # aliases: [Alias]]
-    claims: [Claim]
+    claims(propertyId: String): [Claim]
     # sitelinks: [Sitelink]
   }
 


### PR DESCRIPTION
This is what we want when we say we want to query statements by property id, right?
What about the references? Do we want to apply that rule there as well? I guess I'm slightly confused :sweat_smile: 
```gql
{
  item(id: "q42") {
    id
    label(language: "en") {
      value
    }
    claims(propertyId: "P69") {
      mainsnak {
        property
        ... on PropertyValueSnak {
          datavalue {
            ... on Item {
              id
            }
            ... on StringValue {
              value
            }
          }
        }
      }
    }
  }
}

```