### PR TITLE
Split schema and resolvers into multiple files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,23 @@
-const { ApolloServer } = require('apollo-server');
-const typeDefs = require('./types/item.schema');
-const resolvers = require('./types/item.resolvers');
+const {ApolloServer, makeExecutableSchema} = require('apollo-server');
 
-const server = new ApolloServer({ typeDefs, resolvers });
+const server = new ApolloServer({
+  schema: makeExecutableSchema({
+    typeDefs: [
+      require('./types/query.schema'),
+      require('./types/item/schema'),
+      require('./types/claim/schema'),
+      require('./types/fingerprint/schema')
+    ],
+    resolvers: {
+      ...require('./types/query.resolvers'),
+      ...require('./types/item/resolvers'),
+      ...require('./types/claim/resolvers'),
+      ...require('./types/fingerprint/resolvers')
+    },
+    inheritResolversFromInterfaces: true
+  })
+});
 
 server.listen().then(() => {
-    console.log(`🚀  Server ready at port ${process.env.PORT}`);
+  console.log(`🚀  Server ready at port ${process.env.PORT}`);
 });

--- a/src/types/claim/resolvers.js
+++ b/src/types/claim/resolvers.js
@@ -1,26 +1,20 @@
-const EntityRepository = require('../dataSources/EntityRepository');
+const EntityRepository = require('../../dataSources/EntityRepository');
 
-const entityRepo = new EntityRepository();
+const entityRepo = new EntityRepository(); // should not create a new repository, but reuse the same one that's used elsewhere
 
 module.exports = {
-  Query: {
-    item: (_, { id }) => {
-      return entityRepo.getEntity( id.toUpperCase() );
-    }
-  },
-  Item: {
-    label: (_, args) => {
-      return _.labels[args.language];
-    },
+  StatementsProvider: {
     claims: (_, args) => {
       if( args.propertyId ) {
         return _.claims[args.propertyId];
       }
       return [].concat(...Object.values(_.claims));
     },
-    description: (_, args ) => {
-      return _.descriptions[ args.language ];
-    },
+
+    __resolveType(entity) {
+      // duplicated in StatementsProvider, could be extracted if it pops up more often
+      return entity.type === 'item' ? 'Item' : 'Property';
+    }
   },
   Claim: {
     references: (_) => {
@@ -62,4 +56,4 @@ module.exports = {
       return 'UnknownValue';
     }
   }
-}
+};

--- a/src/types/claim/schema.js
+++ b/src/types/claim/schema.js
@@ -1,32 +1,10 @@
 const { gql } = require('apollo-server');
 
-const typeDefs = gql`
-  type Item {
-    pageid: Int!
-    ns: Int!
-    title: String!
-    lastrevid: Int!
-    modified: String!
-    type: String!
-    id: String!
-    label(language: String): Label
-    ## Implement those later
-    description(language: String): Description
-    # aliases: [Alias]]
+module.exports = gql`
+  interface StatementsProvider {
     claims(propertyId: String): [Claim]
-    # sitelinks: [Sitelink]
   }
-
-  type Label {
-      language: String!
-      value: String!
-  }
-
-  type Description {
-      language: String!
-      value: String!
-  }
-
+  
   type Claim {
     id: String!
     mainsnak: Snak!
@@ -74,9 +52,4 @@ const typeDefs = gql`
     snaks: [Snak]
     snakOrder: [String]
   }
-  type Query {
-    item(id: String!): Item!
-  }
 `;
-
-module.exports = typeDefs;

--- a/src/types/fingerprint/resolvers.js
+++ b/src/types/fingerprint/resolvers.js
@@ -1,0 +1,16 @@
+module.exports = {
+  FingerprintProvider: {
+    label: (_, args) => {
+      return _.labels[args.language];
+    },
+
+    description: (_, args) => {
+      return _.descriptions[args.language];
+    },
+
+    __resolveType(entity) {
+      // duplicated in StatementsProvider, could be extracted if it pops up more often
+      return entity.type === 'item' ? 'Item' : 'Property';
+    }
+  }
+};

--- a/src/types/fingerprint/schema.js
+++ b/src/types/fingerprint/schema.js
@@ -1,0 +1,19 @@
+const { gql } = require('apollo-server');
+
+module.exports = gql`
+  interface FingerprintProvider {
+    label(language: String): Label
+    description(language: String): Description
+    # aliases: [Alias]]
+  }
+
+  type Label {
+    language: String!
+    value: String!
+  }
+
+  type Description {
+    language: String!
+    value: String!
+  }
+`;

--- a/src/types/item/resolvers.js
+++ b/src/types/item/resolvers.js
@@ -1,0 +1,5 @@
+module.exports = {
+  Item: {
+    // sitelinks are the only thing specific to Items that Properties don't have
+  }
+}

--- a/src/types/item/schema.js
+++ b/src/types/item/schema.js
@@ -1,0 +1,19 @@
+const { gql } = require('apollo-server');
+
+const typeDefs = gql`
+  type Item implements FingerprintProvider & StatementsProvider {
+    pageid: Int!
+    ns: Int!
+    title: String!
+    lastrevid: Int!
+    modified: String!
+    type: String!
+    id: String!
+    label(language: String): Label
+    description(language: String): Description
+    claims(propertyId: String): [Claim]
+    # sitelinks: [Sitelink]
+  }
+`;
+
+module.exports = typeDefs;

--- a/src/types/query.resolvers.js
+++ b/src/types/query.resolvers.js
@@ -1,0 +1,11 @@
+const EntityRepository = require('../dataSources/EntityRepository');
+
+const entityRepo = new EntityRepository(); // should not create a new repository, but reuse the same one that's used elsewhere
+
+module.exports = {
+  Query: {
+    item: (_, { id }) => {
+      return entityRepo.getEntity(id.toUpperCase());
+    }
+  }
+};

--- a/src/types/query.schema.js
+++ b/src/types/query.schema.js
@@ -1,0 +1,7 @@
+const { gql } = require('apollo-server');
+
+module.exports = gql`
+  type Query {
+    item(id: String!): Item!
+  }
+`;


### PR DESCRIPTION
I split the schema and resolvers into multiple files/folders:
* `item` contains what's left of the item once everything that's shared between items and properties is extracted (which is not much)
* `claim` contains everything related to claims/statements
* `fingerprint` which contains labels, descriptions, aliases
* `query` which contains the root query schema

I decided to leave the query resolvers and schema in the `types` folder because it makes up the root of the query and put everything else in sub folders. Not sure if that makes sense.