### PR TITLE
Try less hard to find entities in the dummy data

### DIFF
--- a/src/dataSources/EntityRepository.js
+++ b/src/dataSources/EntityRepository.js
@@ -3,7 +3,7 @@ const dummyData = require('./dummyData');
 module.exports = class EntityRepository {
 
   getEntity(id) {
-    return dummyData.entities[id];
+    return dummyData.entities[id] || { id };
   }
 
 };


### PR DESCRIPTION
This query currently breaks for Q42 on master but works again with this patch

```gql
{
  item(id: "q42") {
    id
    label(language: "en") {
      value
    }
    claims {
      mainsnak {
        property
        ... on PropertyValueSnak {
          datavalue {
            ... on Item {
              id
            }
            ... on StringValue {
              value
            }
          }
        }
      }
    }
  }
}
```