### PR TITLE
Add schema and resolver for qualifiers

### DIFF
--- a/src/types/claim/resolvers.js
+++ b/src/types/claim/resolvers.js
@@ -20,7 +20,7 @@ module.exports = {
     references: (_) => {
       return _.references;
     },
-    qualifier: (_, { propertyId }) => {
+    qualifiers: (_, { propertyId }) => {
       if (_.qualifiers ) {
         return _.qualifiers[propertyId];
       }

--- a/src/types/claim/resolvers.js
+++ b/src/types/claim/resolvers.js
@@ -21,10 +21,10 @@ module.exports = {
       return _.references;
     },
     qualifiers: (_, { propertyId }) => {
-      if (_.qualifiers ) {
+      if (_.qualifiers && _.qualifiers[propertyId]) {
         return _.qualifiers[propertyId];
       }
-      return null;
+      return [];
     }
   },
   Reference: {

--- a/src/types/claim/resolvers.js
+++ b/src/types/claim/resolvers.js
@@ -5,7 +5,7 @@ const entityRepo = new EntityRepository(); // should not create a new repository
 module.exports = {
   StatementsProvider: {
     claims: (_, args) => {
-      if( args.propertyId ) {
+      if (args.propertyId) {
         return _.claims[args.propertyId];
       }
       return [].concat(...Object.values(_.claims));
@@ -19,6 +19,12 @@ module.exports = {
   Claim: {
     references: (_) => {
       return _.references;
+    },
+    qualifier: (_, { propertyId }) => {
+      if (_.qualifiers ) {
+        return _.qualifiers[propertyId];
+      }
+      return null;
     }
   },
   Reference: {

--- a/src/types/claim/schema.js
+++ b/src/types/claim/schema.js
@@ -8,7 +8,7 @@ module.exports = gql`
   type Claim {
     id: String!
     mainsnak: Snak!
-    qualifier(propertyId: String): [Qualifier]
+    qualifiers(propertyId: String): [Qualifier]
     references: [Reference]
   }
 

--- a/src/types/claim/schema.js
+++ b/src/types/claim/schema.js
@@ -8,6 +8,7 @@ module.exports = gql`
   type Claim {
     id: String!
     mainsnak: Snak!
+    qualifier(propertyId: String): [Qualifier]
     references: [Reference]
   }
 
@@ -45,6 +46,15 @@ module.exports = gql`
     property: String! # We probably want this to be a Property object and not a string at some point
     snaktype: String!
     datatype: String!
+  }
+
+  type Qualifier implements Snak {
+    property: String! # We probably want this to be a Property object and not a string at some point
+    snaktype: String!
+    datatype: String!
+
+    hash: String!
+    datavalue: Value
   }
 
   type Reference {


### PR DESCRIPTION
```gql
{
  item(id: "q42") {
    id
    label(language: "en") {
      value
    }
    claims(propertyId: "P551") {
      id
      qualifier(propertyId: "P580") {
        property
        snaktype
        datatype
      }
    }
  }
}
```