### PR TITLE
Use dataloader for batching getentities request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,6 +910,11 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "apollo-datasource-rest": "^0.8.1",
     "apollo-server": "^2.12.0",
+    "dataloader": "^2.0.0",
     "graphql": "^15.0.0"
   },
   "devDependencies": {

--- a/src/dataSources/WikibaseActionApi.js
+++ b/src/dataSources/WikibaseActionApi.js
@@ -1,4 +1,5 @@
 const { RESTDataSource } = require('apollo-datasource-rest');
+const DataLoader = require('dataloader');
 
 module.exports = class WikibaseActionApi extends RESTDataSource {
 
@@ -8,13 +9,21 @@ module.exports = class WikibaseActionApi extends RESTDataSource {
   }
 
   async getEntity(id) {
-    const result = await this.get('', {
+    return this.getEntitiesLoader.load(id);
+  }
+
+  getEntitiesLoader = new DataLoader(async (ids) => {
+    const getEntitiesResponse = await this.get('', {
       action: 'wbgetentities',
       format: 'json',
-      ids: [id]
+      ids: ids.join('|')
     });
 
-    return result.entities[id];
+    return ids.map(id => getEntitiesResponse.entities[id]);
+  });
+
+  willSendRequest(request) {
+    console.log(request);
   }
 
 }


### PR DESCRIPTION
Using dataloader as suggested in [the docs](https://www.apollographql.com/docs/apollo-server/data/data-sources/#what-about-dataloader).

As far as I can tell from the log output, this reduces the requests to one request per nesting level as opposed to one request per fetched entity. As long as it doesn't attempt to request more than 50 entities at once, this should work well.

This query caused the API to block my IP without batching (i.e. when run with the code that's currently on master), but works now :tada: 
```gql
{
  item(id: "Q11") {
    id
    label(language: "en") {
      value
    }
    claims {
      mainsnak {
        property {
          label(language: "en") {
            value
          }
        }
        ... on PropertyValueSnak {
          datavalue {
            ... on Item {
              label(language: "en") {
                value
              }
            }
          }
        }
      }
    }
  }
}
```