### PR TITLE
Set dataloader batch size to 50

### DIFF
--- a/src/dataSources/WikibaseActionApi.js
+++ b/src/dataSources/WikibaseActionApi.js
@@ -17,6 +17,8 @@ module.exports = class WikibaseActionApi extends RESTDataSource {
       action: 'wbgetentities',
       format: 'json',
       ids: ids.join('|')
+    }, {
+      maxBatchSize: 50,
     });
 
     return ids.map(id => getEntitiesResponse.entities[id]);


### PR DESCRIPTION
This will split requests for more than 50 items/properties into multiple requests. This means that queries that attempt to fetch data for small multiples of 50 should work, but for really large items it quickly becomes too many requests.