### PR TITLE
Allow filtering terms by multiple languages

### DIFF
--- a/src/types/fingerprint/resolvers.js
+++ b/src/types/fingerprint/resolvers.js
@@ -1,17 +1,20 @@
+function filterTerms(termsMap, { language, languages }) {
+  const terms = Object.values(termsMap);
+  if (language) {
+    languages = [language];
+  }
+
+  return languages ? terms.filter(term => languages.includes(term.language)) : terms;
+}
+
 module.exports = {
   FingerprintProvider: {
-    labels: (_, args) => {
-      if( args.language ) {
-        return [ _.labels[args.language] ];
-      }
-      return [].concat(...Object.values(_.labels) );
+    labels: ({ labels }, args) => {
+      return filterTerms(labels, args);
     },
 
-    descriptions: (_, args) => {
-      if( args.language ) {
-        return [ _.descriptions[args.language] ];
-      }
-      return [].concat(...Object.values(_.descriptions) );
+    descriptions: ({ descriptions }, args) => {
+      return filterTerms(descriptions, args)
     },
 
     aliases: (_, args) => {

--- a/src/types/fingerprint/schema.js
+++ b/src/types/fingerprint/schema.js
@@ -2,8 +2,8 @@ const { gql } = require('apollo-server');
 
 module.exports = gql`
   interface FingerprintProvider {
-    labels(language: String): [Label]
-    descriptions(language: String): [Description]
+    labels(language: String, languages: [String]): [Label]
+    descriptions(language: String, languages: [String]): [Description]
     aliases(language: String): [Alias]
   }
 

--- a/src/types/item/schema.js
+++ b/src/types/item/schema.js
@@ -9,8 +9,8 @@ const typeDefs = gql`
     modified: String!
     type: String!
     id: String!
-    labels(language: String): [Label]
-    descriptions(language: String): [Description]
+    labels(language: String, languages: [String]): [Label]
+    descriptions(language: String, languages: [String]): [Description]
     claims(propertyIDs: [String]): [Claim]
     aliases(language: String): [Alias]
     # sitelinks: [Sitelink]

--- a/src/types/property/schema.js
+++ b/src/types/property/schema.js
@@ -10,8 +10,8 @@ const typeDefs = gql`
     type: String!
     id: String!
     datatype: String!
-    labels(language: String): [Label]
-    descriptions(language: String): [Description]
+    labels(language: String, languages: [String]): [Label]
+    descriptions(language: String, languages: [String]): [Description]
     claims(propertyIDs: [String]): [Claim]
     aliases(language: String): [Alias]
   }


### PR DESCRIPTION
I wasn't sure if once we have this, we'd get rid of `language` as a filter argument? Is it confusing to have both? :man_shrugging: 