### PR TITLE
User agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/wmde/prototype-wikibase-graphql-api.git"
   },
   "keywords": [],
-  "author": "",
+  "author": "The Wikidata team",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/wmde/prototype-wikibase-graphql-api/issues"

--- a/src/dataSources/WikibaseActionApi.js
+++ b/src/dataSources/WikibaseActionApi.js
@@ -18,11 +18,11 @@ module.exports = class WikibaseActionApi extends RESTDataSource {
       action: 'wbgetentities',
       format: 'json',
       ids: ids.join('|')
-    }, {
-      maxBatchSize: 50,
     });
 
     return ids.map(id => getEntitiesResponse.entities[id]);
+  }, {
+    maxBatchSize: 50,
   });
 
   _getUserAgentString() {

--- a/src/dataSources/WikibaseActionApi.js
+++ b/src/dataSources/WikibaseActionApi.js
@@ -1,5 +1,6 @@
 const { RESTDataSource } = require('apollo-datasource-rest');
 const DataLoader = require('dataloader');
+const packageInfo = require('../../package.json');
 
 module.exports = class WikibaseActionApi extends RESTDataSource {
 
@@ -24,8 +25,17 @@ module.exports = class WikibaseActionApi extends RESTDataSource {
     return ids.map(id => getEntitiesResponse.entities[id]);
   });
 
+  _getUserAgentString() {
+    const appInformation = `${packageInfo.name}/${packageInfo.version}`;
+    const authorInfo = `${packageInfo.author}`;
+    const libraryInfo = `apollo-datasource-rest/${packageInfo.dependencies['apollo-datasource-rest']}`;
+
+    return `${appInformation} (${authorInfo}) ${libraryInfo}`;
+  }
+
   willSendRequest(request) {
     console.log(request);
+    request.headers.set('User-agent', this._getUserAgentString());
   }
 
 }


### PR DESCRIPTION
Add `User-agent` to api request headers. This allows us to make requests at a higher frequency before the API shuts us down.

The following query now works with `API_URL=http://wikidata.org/w/api.php`:
```gql
{
  item(id: "Q42") {
    id
    labels(language: "en") {
      value
    }
    claims {
      mainsnak {
        property {
          labels(language: "en") {
            value
          }
        }
        ... on PropertyValueSnak {
          datavalue {
            ... on Item {
              labels(language: "en") {
                value
              }
            }
          }
        }
      }
    }
  }
}
```