### PR TITLE
Remove `language` param for labels/descriptions

### DIFF
--- a/src/types/fingerprint/resolvers.js
+++ b/src/types/fingerprint/resolvers.js
@@ -1,8 +1,5 @@
-function filterTerms(termsMap, { language, languages }) {
+function filterTerms(termsMap, { languages }) {
   const terms = Object.values(termsMap);
-  if (language) {
-    languages = [language];
-  }
 
   return languages ? terms.filter(term => languages.includes(term.language)) : terms;
 }

--- a/src/types/fingerprint/schema.js
+++ b/src/types/fingerprint/schema.js
@@ -2,8 +2,8 @@ const { gql } = require('apollo-server');
 
 module.exports = gql`
   interface FingerprintProvider {
-    labels(language: String, languages: [String]): [Label]
-    descriptions(language: String, languages: [String]): [Description]
+    labels(languages: [String]): [Label]
+    descriptions(languages: [String]): [Description]
     aliases(language: String): [Alias]
   }
 

--- a/src/types/item/schema.js
+++ b/src/types/item/schema.js
@@ -9,8 +9,8 @@ const typeDefs = gql`
     modified: String!
     type: String!
     id: String!
-    labels(language: String, languages: [String]): [Label]
-    descriptions(language: String, languages: [String]): [Description]
+    labels(languages: [String]): [Label]
+    descriptions(languages: [String]): [Description]
     claims(propertyIDs: [String]): [Claim]
     aliases(language: String): [Alias]
     sitelinks(sites: [String]): [Sitelink]

--- a/src/types/property/schema.js
+++ b/src/types/property/schema.js
@@ -10,8 +10,8 @@ const typeDefs = gql`
     type: String!
     id: String!
     datatype: String!
-    labels(language: String, languages: [String]): [Label]
-    descriptions(language: String, languages: [String]): [Description]
+    labels(languages: [String]): [Label]
+    descriptions(languages: [String]): [Description]
     claims(propertyIDs: [String]): [Claim]
     aliases(language: String): [Alias]
   }


### PR DESCRIPTION
Having both `language` and `languages` is confusing.